### PR TITLE
false-tubolinks

### DIFF
--- a/app/views/home/_footer.html.haml
+++ b/app/views/home/_footer.html.haml
@@ -74,6 +74,7 @@
         = image_tag "Logo_white.png", width:124, height:33
       %span.footer-bottom__copyright
         %small © 2019 mercari
+%div{"data-turbolinks": "false"}
   =link_to new_item_path, class: "sell-btn" do
     .sell-btn__title 出品 
     %i.fas.fa-camera

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -76,7 +76,7 @@
           %i.fas.fa-lock
           %span.key あんしん・あんぜんへの取り組み
   - if user_signed_in? && current_user.id == @item.user_id
-    .principal
+    .principal{"data-turbolinks": "false"}
       = link_to '商品の編集', edit_item_path(@item), class: 'principal__tab'
       %p or
       = link_to '出品を一旦停止する', '', class: 'principal__tab--gray'


### PR DESCRIPTION
# What
{"data-turbolinks": "false"}を
編集ページと出品ページに適用

# Why
turbolinksによる予期しない挙動を削除するため