### PR TITLE
add__dependent-destroy

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   belongs_to :user
   belongs_to :category
   has_many :images, dependent: :destroy
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
   def like_user(user_id)


### PR DESCRIPTION
# What
itemとcomments間のアソシエーションに下記オプション追加
 dependent: :destroy

# Why
削除機能の考慮漏れ修正のため