### PR TITLE
Sns認証 パスワードなしで登録

### DIFF
--- a/app/assets/stylesheets/devise/sessions.scss
+++ b/app/assets/stylesheets/devise/sessions.scss
@@ -64,7 +64,7 @@
           border: 0.5px solid #808080;
           &-icon {
             position: absolute;
-            top: 14px;
+            top: 24px;
             left: 14px;
             width: 22px;
             height: 22px;

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,8 +4,14 @@ class SessionsController < Devise::SessionsController
   def user_info_keep
     session[:nickname] = params[:nickname]
     session[:email] = params[:email]
-    session[:password] = params[:password]
-    session[:password_confirmation] = params[:password_confirmation]
+    if session[:uid].present? && session[:provider].present?
+      # SNS認証(mniauthCallbacksController)で自動生成したパスワードを使用
+      # flash[:sns] = "have_password_with_sns"
+      @tester = "have_password_with_sns"
+    else
+      session[:password] = params[:password]
+      session[:password_confirmation] = params[:password_confirmation]
+    end
     session[:last_name] = params[:last_name]
     session[:first_name] = params[:first_name]
     session[:last_name_kana] = params[:last_name_kana]
@@ -80,6 +86,7 @@ class SessionsController < Devise::SessionsController
       session[:address_number].blank?
       # JSで入力エラー表示
     else
+      
       User.create!(
         nickname: session[:nickname],
         email: session[:email],

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,9 +5,7 @@ class SessionsController < Devise::SessionsController
     session[:nickname] = params[:nickname]
     session[:email] = params[:email]
     if session[:uid].present? && session[:provider].present?
-      # SNS認証(mniauthCallbacksController)で自動生成したパスワードを使用
-      # flash[:sns] = "have_password_with_sns"
-      @tester = "have_password_with_sns"
+      # SNS認証(omniauthCallbacksController)で自動生成したパスワードを使用
     else
       session[:password] = params[:password]
       session[:password_confirmation] = params[:password_confirmation]

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,12 +9,18 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def callback_for(provider)
     @user = User.find_oauth(request.env["omniauth.auth"]) #userモデルに飛ぶ
+
     if @user[:sns].present?
       # SNS経由で会員登録済
       sign_in_and_redirect @user[:user][0]
     else
       # SNS経由で会員登録未済 
-      @test = @user[:user][:nickname]
+      flash[:nickname] = @user[:user][:nickname]
+      flash[:email] = @user[:user][:email]
+      flash[:sns] = "have_password_with_sns"
+      password_token = Devise.friendly_token.first(10) #deviseのパスワード自動生成機能を使用
+      session[:password] = password_token 
+      session[:password_confirmation] = password_token
       session[:uid] = @user[:uid]
       session[:provider] = @user[:provider]
       redirect_to new_user_registration_path

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -18,7 +18,7 @@
             %span.form-content__bottom__box--require
               必須
           .form-content__bottom__box--input
-            = f.text_field :nickname, placeholder: "例)メルカリ太郎", type: "text",class: "form-content__bottom__box--input--name"
+            = f.text_field :nickname, placeholder: "例)メルカリ太郎", type: "text",class: "form-content__bottom__box--input--name", value: flash[:nickname]
             -# エラーメッセージ表示
             .err_nickname
         -# メールアドレス
@@ -29,12 +29,13 @@
             %span.form-content__bottom__box--require
               必須
           .form-content__bottom__box--input
-            = f.email_field :email, placeholder: "PC・携帯どちらでも可", type: "text", class: "form-content__bottom__box--input--name"
+            = f.email_field :email, placeholder: "PC・携帯どちらでも可", type: "text", class: "form-content__bottom__box--input--name", value: flash[:email]
             -# エラーメッセージ表示
             .err_email
             .err_email_format
         -# パスワード
         .form-content__bottom__box
+        - if flash[:sns].nil? # SNS認証はパスワード表示なし
           .form-content__bottom__box--title
             = f.label :password, class: "form-content__bottom__box--title--text" do
               パスワード
@@ -47,6 +48,7 @@
             .err_passwordlength
         -# パスワード(確認)
         .form-content__bottom__box
+        - if flash[:sns].nil? # SNS認証はパスワード表示なし
           .form-content__bottom__box--title
             = f.label :password, class: "form-content__bottom__box--title--text" do
               パスワード(確認)


### PR DESCRIPTION
## WHAT
・SNS認証時にパスワード登録なし（パスワード項目を非表示に）に実装
・SNS認証時はニックネーム項目とメールアドレス項目に初期値を設定
・ログイン画面のgoogleアイコンの崩れを修正

## WHY
・上記について確認していただくため